### PR TITLE
Added default.json to reference quiet.json5

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default preset that extends quiet configuration",
+  "extends": ["github>tryghost/renovate-config:quiet.json5"]
+}

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Onboarding preset for use with Ghost's repos",
-  "extends": ["github>tryghost/renovate-config:quiet"]
+  "extends": ["github>tryghost/renovate-config"]
 }

--- a/test.sh
+++ b/test.sh
@@ -44,6 +44,8 @@ git commit -m "Initial commit" -q
 echo "Running Renovate dry-run..."
 output=$(RENOVATE_CONFIG_FILE=../quiet.json5 npx -p renovate renovate --platform=local --dry-run 2>&1)
 
+echo "$output"
+
 if echo "$output" | grep -E "(Cannot find preset|Failed to look up preset)" > /dev/null; then
   echo "❌ ERROR: Preset resolution failed"
   echo "   External repos cannot use 'github>tryghost/renovate-config'"

--- a/test.sh
+++ b/test.sh
@@ -33,7 +33,7 @@ EOF
 # Create a renovate.json that uses our preset (like external repos would)
 cat > renovate.json << EOF
 {
-  "extends": ["github>tryghost/renovate-config:quiet"]
+  "extends": ["github>tryghost/renovate-config"]
 }
 EOF
 
@@ -44,12 +44,9 @@ git commit -m "Initial commit" -q
 echo "Running Renovate dry-run..."
 output=$(RENOVATE_CONFIG_FILE=../quiet.json5 npx -p renovate renovate --platform=local --dry-run 2>&1)
 
-echo "$output"
-
 if echo "$output" | grep -E "(Cannot find preset|Failed to look up preset)" > /dev/null; then
   echo "❌ ERROR: Preset resolution failed"
-  echo "   External repos cannot use 'github>tryghost/renovate-config:quiet'"
-  echo "   They need to use 'github>tryghost/renovate-config:quiet.json5'"
+  echo "   External repos cannot use 'github>tryghost/renovate-config'"
   cd ..
   rm -rf test-repo
   exit 1


### PR DESCRIPTION
ref: https://github.com/TryGhost/Ghost/commit/dc0816a908e81f8938a774014432445fa5b1a64f

- Renovate does not support loading a json5 file when referencing it just as `github>tryghost/renovate-config:quiet`
- Instead, it needs the full path like `github>tryghost/renovate-config:quiet.json5`
- But this is ugly and annoying. Ideally, we'd have a default preset and not bother with the quiet naming
- We can solve both problems by having a default.json that only extends quiet.json5
- This way all the renovate configs just have to be updated to "extends": ["github>tryghost/renovate-config"]
- It's smarter and we get to keep the json5 file with comments and syntax in editors