### PR TITLE
Changed tryghost etc to automerge for non-major

### DIFF
--- a/quiet.json5
+++ b/quiet.json5
@@ -84,15 +84,17 @@
             ],
             "automerge": true
         },
-        // Don't automerge @tryghost/ packages, gscan, or knex-migrator
-        // TODO: review this one, automerge patch updates at least?
+        // Don't automerge major bumps for @tryghost/ packages, gscan, or knex-migrator
+        // If you don't want renovate to automerge your changes, make them majors
         {
             "matchPackagePatterns": [
                 "^@tryghost/.+",
                 "gscan",
                 "knex-migrator"
             ],
-            "automerge": false
+            "major": {
+                "automerge": false
+            }
         },
         // Group types packages together
         {


### PR DESCRIPTION
ref https://github.com/TryGhost/slimer/commit/3f008001327ab2c92acbd96f534632eefe8ebe2b  
ref https://github.com/TryGhost/slimer/commit/e79747eca619cacd1f73064a396bb602037a9cec  
ref https://github.com/TryGhost/renovate-config/commit/366dab6ca9bdcb80de0187346ddbd6c21913786f

- Gscan was restricted from automerge because we sometimes want to do emoji-bumps IMO: we usually do the emoji bump on the feature code, not the gscan bump
- TryGhost packages were restricted to encourage writing our own commit messages IMO: The detailed commit is in the package, and we gain a lot by having renovate do the work of automerging
- Knex-migrator seemingly was added when we moved from slimer to this repo without any explanation
- I've left majors to NOT automerge - so if we really want to write our own commits or add emojis we should publish new majors