### PR TITLE
Enable renovate for renovate repo

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,5 @@
+{
+    "extends": [
+        "github>tryghost/renovate-config"
+    ],
+}


### PR DESCRIPTION
no ref

- This helps add some status checks when we want to change config, without this Renovate doesn't comment on things explaining the config which is quite helpful