### PR TITLE
Add uses-with to automerge matchDepTypes

### DIFF
--- a/quiet.json5
+++ b/quiet.json5
@@ -48,7 +48,8 @@
                 "optionalDependencies",
                 "peerDependencies",
                 "packageManager",
-                "action"
+                "action",
+                "uses-with"
             ],
             "automerge": true,
             "automergeType": "pr"


### PR DESCRIPTION
## Summary

- Adds `uses-with` to the `matchDepTypes` list in the automerge package rule
- The `github-actions` manager classifies version inputs from action `with:` blocks (e.g. `pnpm/action-setup`'s `version` field) as dep type `uses-with` rather than `action`
- Without this, minor/patch updates for pnpm (and other tool versions set via `with:`) were excluded from automerge