### PR TITLE
Pin @elastic/elasticsearch to v8

### DIFF
--- a/quiet.json5
+++ b/quiet.json5
@@ -148,6 +148,17 @@
                 "metascraper"
             ],
             "groupName": "metascraper"
+        },
+        // Pin @elastic/elasticsearch and @elastic/transport to v8 — production
+        // runs ElasticSearch 8 (ref INC-275). Renovate will not propose v9
+        // bumps until this rule is lifted.
+        {
+            "description": "Pin @elastic/elasticsearch to v8",
+            "matchPackageNames": [
+                "@elastic/elasticsearch",
+                "@elastic/transport"
+            ],
+            "allowedVersions": "<9"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Production currently runs ElasticSearch 8 (ref [INC-275](https://app.incident.io/ghost/incidents/275)). A renovate-driven bump to v9 landed in `framework` and caused issues — see [TryGhost/framework#590](https://github.com/TryGhost/framework/pull/590) for the in-repo downgrade and version-assert test.

This adds an `allowedVersions: "<9"` rule for both `@elastic/elasticsearch` and `@elastic/transport` so renovate will stop proposing v9 upgrades across every Ghost repo that extends this preset, rather than each repo having to enforce the pin individually (and waste CI cycles failing the version-assert on each renovate PR).

When we're ready to migrate to v9, lift this rule.

## Test plan

- [x] `bash test.sh` (renovate-config-validator) passes locally
- [ ] Confirm framework's next renovate run no longer opens an `@elastic/elasticsearch` v9 PR