### PR TITLE
Added theme Renovate preset

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,3 +6,4 @@ echo "🧪 Testing Renovate config..."
 # Test 1: Validate syntax
 echo "→ Validating syntax..."
 RENOVATE_CONFIG_FILE=quiet.json5 npx -p renovate renovate-config-validator
+RENOVATE_CONFIG_FILE=theme.json5 npx -p renovate renovate-config-validator

--- a/theme.json5
+++ b/theme.json5
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "description": "Base configuration rules for Ghost theme repos",
+    "extends": [
+        "github>tryghost/renovate-config:quiet.json5"
+    ],
+    "packageRules": [
+        // Keep beeper on v2 for theme build compatibility.
+        {
+            "matchPackageNames": [
+                "beeper"
+            ],
+            "allowedVersions": "<3.0.0"
+        }
+    ]
+}

--- a/theme.json5
+++ b/theme.json5
@@ -5,6 +5,16 @@
         "github>tryghost/renovate-config:quiet.json5"
     ],
     "packageRules": [
+        {
+            "matchPackageNames": [
+                "@tryghost/theme-translations"
+            ],
+            "automerge": true,
+            "automergeType": "pr",
+            "schedule": [
+                "every weekday"
+            ]
+        },
         // Keep beeper on v2 for theme build compatibility.
         {
             "matchPackageNames": [


### PR DESCRIPTION
## Summary
- Added a repo-hosted `theme.json5` preset for Ghost theme repositories
- Extended the shared `quiet.json5` defaults so theme repos inherit the org Renovate practices
- Preserved the old theme-specific `beeper <3.0.0` compatibility constraint
- Centralized the `@tryghost/theme-translations` weekday PR automerge rule in the theme preset
- Updated `test.sh` to validate the new preset

## Testing
- `./test.sh`