### PR TITLE
Added temporary safe Renovate preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Renovate presets for our GitHub repositories
 
+## Presets
+
+- `default` - Quiet configuration with automerge enabled for dependency upgrades
+- `safe` - Same as `default`, but major dependency upgrades are not automerged. This preset is an anti-pattern and should only be used as a temporary solution until CI tests are reliable enough to use `default`.
+- `theme` - Base configuration rules for Ghost theme repositories
+- `terraform` - Base configuration rules for Terraform repositories
+
 ## Validation
 
 ### Quick test

--- a/safe.json
+++ b/safe.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Temporary anti-pattern preset that extends default configuration without automerging major dependency upgrades",
+  "extends": ["github>tryghost/renovate-config"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}

--- a/test.sh
+++ b/test.sh
@@ -6,4 +6,5 @@ echo "🧪 Testing Renovate config..."
 # Test 1: Validate syntax
 echo "→ Validating syntax..."
 RENOVATE_CONFIG_FILE=quiet.json5 npx -p renovate renovate-config-validator
+RENOVATE_CONFIG_FILE=safe.json npx -p renovate renovate-config-validator
 RENOVATE_CONFIG_FILE=theme.json5 npx -p renovate renovate-config-validator


### PR DESCRIPTION
## Summary

- Added a `safe` Renovate preset that inherits the default preset while disabling automerge for major updates.
- Documented that `safe` is an anti-pattern intended only as a temporary bridge until CI is reliable enough for `default`.
- Added `safe.json` to the validation script.

## Testing

- `./test.sh`