### PR TITLE
Improve repository documentation for preset consumers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ node --check test/serve-presets.mjs
 
 - `default.json` is the entrypoint for consumers that extend `local>TryGhost/renovate-config` without a preset name.
 - `quiet.json5` owns the shared policy used by the default and theme presets. It broadly enables dependency automerge, then applies explicit exceptions and compatibility limits.
-- `safe.json` is a temporary alternative for repositories whose CI cannot safely validate major dependency updates.
+- `safe.json` is an anti-pattern and should be avoided. It exists only as a temporary fallback for repositories whose CI cannot safely validate major dependency updates.
 - `renovate-config.json` is a separate onboarding configuration, not the default consumer entrypoint. The current harness validates its syntax but does not exercise its remote preset resolution.
 - Presets are consumed from the default branch. A semantically valid-looking edit can change dependency behavior across many repositories immediately after merge.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,38 @@
 # AGENTS.md
 
-This file provides guidance to agents when working with code in this repository.
-
-## Repository Overview
-
-This is a Renovate configuration repository that provides presets for Ghost Foundation's GitHub repositories. It defines how the Renovate bot should handle dependency updates across Ghost's projects.
-
-## Key Files
-
-- `renovate-config.json` - Main preset file that extends the quiet configuration
-- `quiet.json5` - Base configuration with detailed rules for dependency updates, package grouping, and automerge settings
+This repository publishes shared Renovate presets for Ghost Foundation repositories. See [README.md](README.md) for consumer usage.
 
 ## Commands
 
-### Validation
-Validate the configuration syntax:
+Use the repository's pinned Node.js and Renovate versions:
+
 ```bash
+nvm use
+npm install --global renovate@43.262.2
 ./test.sh
 ```
 
-### Testing
-Test configuration changes against a repository:
-```bash
-# Basic dry-run test
-npx -p renovate renovate --platform=local --dry-run=extract --onboarding=false --require-config=required
+`./test.sh` is the authoritative validation command. It must pass before a preset or test-harness change is ready for review.
 
-# Test with specific configuration
-RENOVATE_CONFIG_FILE=/path/to/config \
-  npx -p renovate renovate --platform=local --dry-run=extract --onboarding=false --require-config=required
+Useful focused checks while editing the harness are:
+
+```bash
+bash -n test.sh
+node --check test/serve-presets.mjs
 ```
 
-## Architecture & Configuration Approach
+## Repository boundaries
 
-The configuration uses a hierarchical approach:
-1. `renovate-config.json` serves as the entry point that other repositories reference
-2. `quiet.json5` contains the actual configuration rules with:
-   - Package grouping rules (e.g., all Vite packages grouped together, TryGhost packages grouped)
-   - Automerge rules based on package type and version (major/minor/patch)
-   - Special handling for test/linting dependencies
-   - Schedule constraints to avoid overwhelming maintainers
+- `default.json` is the entrypoint for consumers that extend `local>TryGhost/renovate-config` without a preset name.
+- `quiet.json5` owns the shared policy used by the default and theme presets. It broadly enables dependency automerge, then applies explicit exceptions and compatibility limits.
+- `safe.json` is a temporary alternative for repositories whose CI cannot safely validate major dependency updates.
+- `renovate-config.json` is a separate onboarding configuration, not the default consumer entrypoint. The current harness validates its syntax but does not exercise its remote preset resolution.
+- Presets are consumed from the default branch. A semantically valid-looking edit can change dependency behavior across many repositories immediately after merge.
 
-Key configuration principles:
-- Pin all dependencies for determinism
-- Group related packages to reduce PR noise
-- Automerge minor/patch updates for stable packages (>= 1.0.0)
-- Always require approval for major updates
-- Maintain lock files weekly to catch transitive dependency issues
+Do not change preset semantics as incidental cleanup. When a semantic change is required, keep it narrow, explain the affected consumers, and add or update a consumer-level regression check.
+
+## Test architecture
+
+`test.sh` enforces the version in `.nvmrc`, validates the configuration files, and creates an isolated consumer fixture. `test/serve-presets.mjs` serves rewritten copies of the checked-out presets over loopback so nested `extends` references resolve to the branch under test instead of published `main`. The fixture exercises npm and Terraform extraction without adding a root package manifest or repository dependencies.
+
+Temporary files and the loopback server are cleaned up by the harness. Keep fixtures deterministic and do not add credentials, network tokens, or generated dependency state to the repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,12 @@ This repository publishes shared Renovate presets for Ghost Foundation repositor
 
 ## Commands
 
-Use the repository's pinned Node.js and Renovate versions:
+Use the Node.js version declared in `.nvmrc`. The CI workflow is the source of truth for its Renovate version. For local validation, use `npx` so Renovate remains a temporary tool rather than a global or repository dependency.
 
 ```bash
+nvm install
 nvm use
-npm install --global renovate@43.262.2
-./test.sh
+npx --yes --package=renovate --call './test.sh'
 ```
 
 `./test.sh` is the authoritative validation command. It must pass before a preset or test-harness change is ready for review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ npx --yes --package=renovate --call './test.sh'
 
 `./test.sh` is the authoritative validation command. It must pass before a preset or test-harness change is ready for review.
 
+The local harness does not require a GitHub token. A full dry run against a live GitHub repository does; follow the README's live-validation instructions and never commit or print `GITHUB_RENOVATE_TOKEN`.
+
 Useful focused checks while editing the harness are:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Use a named preset when the repository needs a more specific policy:
 
 ## Validating changes
 
-The test harness requires Node.js 24.11.0 and Renovate 43.262.2. Install the pinned Renovate CLI globally so the repository remains dependency-free:
+The test harness uses the Node.js version declared in [`.nvmrc`](.nvmrc). The [test workflow](.github/workflows/test.yml) is the source of truth for the Renovate version used in CI. For local validation, use `npx` to make Renovate temporarily available to the harness without adding a global or repository dependency:
 
 ```bash
+nvm install
 nvm use
-npm install --global renovate@43.262.2
-./test.sh
+npx --yes --package=renovate --call './test.sh'
 ```
 
 The test command validates every configuration file, applies strict validation where the current presets support it, resolves the consumable presets through a temporary loopback server, and runs dependency extraction against npm and Terraform fixtures.

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Preset changes affect repositories across the Ghost Foundation organization. Kee
 
 # Copyright & License
 
-Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE). Ghost and the Ghost Logo are trademarks of Ghost Foundation Ltd. Please see our [trademark policy](https://ghost.org/trademark/) for info on acceptable usage.
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ npx --yes --package=renovate --call './test.sh'
 
 The test command validates every configuration file, applies strict validation where the current presets support it, resolves the consumable presets through a temporary loopback server, and runs dependency extraction against npm and Terraform fixtures.
 
+### Live repository dry run
+
+The local test harness does not need GitHub credentials. To exercise a preset against the live `TryGhost/Ghost` repository, create a personal access token following [Renovate's GitHub authentication guidance](https://docs.renovatebot.com/modules/platform/github/#authentication) and expose it as `GITHUB_RENOVATE_TOKEN` through your shell or secret manager. Then run from the repository root:
+
+```bash
+RENOVATE_CONFIG_FILE="$PWD/quiet.json5" \
+RENOVATE_TOKEN="$GITHUB_RENOVATE_TOKEN" \
+npx --yes --package=renovate renovate \
+  --platform=github \
+  --dry-run=full \
+  TryGhost/Ghost
+```
+
+Change `RENOVATE_CONFIG_FILE` when testing a different preset. Never commit or print the token.
+
 Preset changes affect repositories across the Ghost Foundation organization. Keep changes narrowly scoped and use the full test command before opening a pull request.
 
 # Copyright & License

--- a/README.md
+++ b/README.md
@@ -1,55 +1,43 @@
 # Renovate Config
 
-Renovate presets for our GitHub repositories
+Shared Renovate presets that control dependency updates across Ghost Foundation repositories.
 
-## Presets
+## Using the presets
 
-- `default` - Quiet configuration with automerge enabled for dependency upgrades
-- `safe` - Same as `default`, but major dependency upgrades are not automerged. This preset is an anti-pattern and should only be used as a temporary solution until CI tests are reliable enough to use `default`.
-- `theme` - Base configuration rules for Ghost theme repositories
-- `terraform` - Base configuration rules for Terraform repositories
+Reference the appropriate preset from a dedicated Renovate configuration file in the consuming repository:
 
-## Validation
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>TryGhost/renovate-config"]
+}
+```
 
-### Quick test
+Use a named preset when the repository needs a more specific policy:
 
-Run all tests (validation, preset resolution, and dry run):
+| Preset | Reference | Purpose |
+| --- | --- | --- |
+| `default` | `local>TryGhost/renovate-config` | Extends `quiet.json5` with broad automerge and its documented exceptions. |
+| `safe` | `local>TryGhost/renovate-config:safe` | Extends `default` but disables major-update automerge. Use it temporarily while CI cannot safely validate major updates. |
+| `theme` | `local>TryGhost/renovate-config:theme.json5` | Extends `quiet.json5` with rules for Ghost theme repositories. |
+| `terraform` | `local>TryGhost/renovate-config:terraform.json5` | Applies Terraform-specific labels, version limits, and automerge policy. |
+
+`quiet.json5` is the shared policy layer behind the default and theme presets. Consuming repositories should normally select one of the public presets above rather than extend it directly.
+
+## Validating changes
+
+The test harness requires Node.js 24.11.0 and Renovate 43.262.2. Install the pinned Renovate CLI globally so the repository remains dependency-free:
 
 ```bash
+nvm use
+npm install --global renovate@43.262.2
 ./test.sh
 ```
 
-### Manual validation
+The test command validates every configuration file, applies strict validation where the current presets support it, resolves the consumable presets through a temporary loopback server, and runs dependency extraction against npm and Terraform fixtures.
 
-You can validate the config syntax by running
-
-```bash
-npx -p renovate renovate-config-validator
-```
-
-This is run in CI, to try to prevent bad config
-
-## Testing
-
-1. Install Renovate CLI:
-   ```bash
-   npm install -g renovate
-   ```
-
-2. Create a GITHUB_RENOVATE_TOKEN token
-
-Create a new [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) in GitHub
-
-   ```bash
-   export GITHUB_RENOVATE_TOKEN=[your token here]
-   ```
-
-3. Run the following command
-
-```bash
-RENOVATE_CONFIG_FILE=~/Sites/renovate-config/quiet.json5 RENOVATE_TOKEN=$GITHUB_RENOVATE_TOKEN renovate --dry-run=full TryGhost/Ghost
-```
+Preset changes affect repositories across the Ghost Foundation organization. Keep changes narrowly scoped and use the full test command before opening a pull request.
 
 # Copyright & License
 
-Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE). Ghost and the Ghost Logo are trademarks of Ghost Foundation Ltd. Please see our [trademark policy](https://ghost.org/trademark/) for info on acceptable usage.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use a named preset when the repository needs a more specific policy:
 | Preset | Reference | Purpose |
 | --- | --- | --- |
 | `default` | `local>TryGhost/renovate-config` | Extends `quiet.json5` with broad automerge and its documented exceptions. |
-| `safe` | `local>TryGhost/renovate-config:safe` | Extends `default` but disables major-update automerge. Use it temporarily while CI cannot safely validate major updates. |
+| `safe` | `local>TryGhost/renovate-config:safe` | Extends `default` but disables major-update automerge. This preset is an anti-pattern; avoid it and use it only temporarily when unavoidable. |
 | `theme` | `local>TryGhost/renovate-config:theme.json5` | Extends `quiet.json5` with rules for Ghost theme repositories. |
 | `terraform` | `local>TryGhost/renovate-config:terraform.json5` | Applies Terraform-specific labels, version limits, and automerge policy. |
 


### PR DESCRIPTION
## Summary

- document supported preset references and their intended use
- explicitly identify the safe preset as an anti-pattern that should be avoided
- replace stale global-install instructions with source-of-truth links and an ephemeral npx workflow
- preserve the token-authenticated full dry run against TryGhost/Ghost as a separate live integration check
- correct agent guidance about preset entrypoints, semantic-change boundaries, and the local test harness

## Verification

- nvm install
- nvm use
- npx --yes --package=renovate --call ./test.sh
- local harness passed with GITHUB_RENOVATE_TOKEN, RENOVATE_TOKEN, and GITHUB_TOKEN explicitly unset
- shellcheck test.sh
- bash -n test.sh
- node --check test/serve-presets.mjs
- git diff --check

The live TryGhost/Ghost dry run was not executed because GITHUB_RENOVATE_TOKEN is unavailable in this environment.

This PR changes documentation only. It adds no global or repository dependencies and does not change preset semantics.