### PR TITLE
Track Renovate CLI updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,20 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "github>tryghost/renovate-config"
+        "local>TryGhost/renovate-config"
     ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "description": "Update the Renovate CLI used by preset validation",
+            "managerFilePatterns": [
+                "/^\\.github\\/workflows\\/test\\.yml$/"
+            ],
+            "matchStrings": [
+                "npx --yes --package=renovate@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+            ],
+            "depNameTemplate": "renovate",
+            "datasourceTemplate": "npm"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary

- add a scoped regex custom manager so Renovate discovers and updates the ephemeral Renovate CLI pin in `.github/workflows/test.yml`
- add the Renovate schema reference and canonicalize the existing shared preset reference to `local>TryGhost/renovate-config`
- keep the repository dependency-free: no manifest, lockfile, installed package, or global tool is added

## Preset and trust decision

The active config remains at `.github/renovate.json5`; it is updated in place and continues to use the shared `default` preset, now in canonical `local>` form. CI trust is verified **Medium**: every consumable preset boundary has meaningful resolution, policy, and extraction acceptance coverage, but the Bash harness does not enforce 80% line/function/branch coverage. Keeping `default` at Medium trust is an explicit project decision because `safe` is considered an anti-pattern and should be avoided. No shared preset file or preset semantics change here.

## Overrides and compatibility

- retained: the existing shared default preset, canonicalized without semantic change
- added: one repository-local regex manager scoped to `.github/workflows/test.yml`; it matches the exact `npx --yes --package=renovate@…` command so unrelated workflow text cannot become a false dependency
- dropped: none
- package.json migration: none; the repository has no root manifest
- runtime/package-manager compatibility rules: none; `.nvmrc` is intentionally updated by Renovate and there is no repository package manager

## Verification

- `renovate-config-validator --strict .github/renovate.json5`
- full `test/run.sh` acceptance suite against all seven configuration boundaries
- real Renovate extraction returned exactly one npm dependency named `renovate` at the pinned CLI version
- `git diff --check`

All commands used the Renovate CLI ephemerally through `npx`; no global dependency was installed.