### PR TITLE
Changed rebaseWhen from automerging to conflicted

### DIFF
--- a/quiet.json5
+++ b/quiet.json5
@@ -28,8 +28,12 @@
     // Don't have separate PRs for minor and patch updates
     "separateMinorPatch": false,
     // https://docs.renovatebot.com/configuration-options/#rebasewhen
-    // Let renovate rebase PRs when automerging
-    "rebaseWhen": "automerging",
+    // Rebase only when a branch actually conflicts. "automerging" resolves to
+    // "never" for any PR a package rule excludes from automerge, so those PRs
+    // went stale; "behind-base-branch" force-pushes and re-runs CI on every
+    // base commit for no gain when branch protection doesn't require branches
+    // to be up to date.
+    "rebaseWhen": "conflicted",
     // Run `yarn-deduplicate --strategy highest` after yarn.lock updates
     "postUpdateOptions": [
         "yarnDedupeHighest"

--- a/test/assert-preset.mjs
+++ b/test/assert-preset.mjs
@@ -82,7 +82,7 @@ function isBroadAutomergeRule(rule) {
 function assertQuietPolicy(shallowConfig, fullConfig) {
     assert.equal(shallowConfig.separateMultipleMajor, false);
     assert.equal(shallowConfig.separateMinorPatch, false);
-    assert.equal(shallowConfig.rebaseWhen, 'automerging');
+    assert.equal(shallowConfig.rebaseWhen, 'conflicted');
     assert.deepEqual(shallowConfig.postUpdateOptions, ['yarnDedupeHighest']);
     assert.equal(shallowConfig.lockFileMaintenance.automerge, true);
 


### PR DESCRIPTION
## Summary

Changes the shared `quiet.json5` preset's `rebaseWhen` from `automerging` to `conflicted`, and updates the harness assertion to match.

## Why

- `automerging` resolves to `never` for any PR a package rule excludes from automerge (CSS preprocessors, `@tryghost/*` majors, etc.), so those review-required PRs never got rebased and went stale.
- `conflicted` rebases only when a branch genuinely conflicts with the base, so every PR stays mergeable without the force-push + full CI re-run per base commit that `behind-base-branch` would cause.
- Ghost already overrides this locally in its `.github/renovate.json5`; this brings the shared preset in line so every consumer repo gets the same behaviour.

## Affected consumers

Every repo extending `github>tryghost/renovate-config` (default/quiet/theme). Non-automerge Renovate PRs will now be rebased when they conflict with the base branch instead of never; automerge PRs behave the same as before except they are no longer rebased when merely behind (they were only rebased when automerging anyway, and branch protection doesn't require up-to-date branches).

## Verification

`npx --yes --package=renovate@43.262.2 --call './test/run.sh'` — all presets validate and acceptance checks pass.