### PR TITLE
Removed CSS preprocessor automerge exclusion

### DIFF
--- a/quiet.json5
+++ b/quiet.json5
@@ -54,36 +54,6 @@
             "automerge": true,
             "automergeType": "pr"
         },
-        // Keep CSS/style pipeline updates out of automerge for manual review
-        {
-            "description": "Do not automerge CSS preprocessors",
-            "matchPackageNames": [
-                "/^postcss/",
-                "/^css/",
-                "/^sass/",
-                "/^less/",
-                "/^styl/",
-                "autoprefixer",
-                "cssnano",
-                "postcss",
-                "postcss-cli",
-                "postcss-import",
-                "postcss-custom-media",
-                "postcss-custom-properties",
-                "postcss-color-mod-function",
-                "postcss-easy-import",
-                "ember-cli-postcss",
-                "gulp-postcss",
-                "sass",
-                "node-sass",
-                "sass-embedded",
-                "less",
-                "stylus",
-                "stylelint",
-                "tailwindcss"
-            ],
-            "automerge": false
-        },
         // Don't automerge major bumps for @tryghost/ packages, gscan, or knex-migrator
         {
             "matchPackageNames": [

--- a/test/assert-preset.mjs
+++ b/test/assert-preset.mjs
@@ -62,10 +62,6 @@ function findEvent(events, message) {
     return event;
 }
 
-function hasDescription(rule, description) {
-    return rule.description?.includes(description) === true;
-}
-
 function findRule(rules, predicate, description) {
     const rule = rules.find(predicate);
     assert.ok(rule, `Resolved policy is missing ${description}`);
@@ -109,12 +105,10 @@ function assertQuietPolicy(shallowConfig, fullConfig) {
         'action',
         'uses-with'
     ]);
-    const cssExceptionRule = findRule(
-        rules,
-        (rule) => hasDescription(rule, 'Do not automerge CSS preprocessors') &&
-            rule.matchPackageNames?.includes('postcss') &&
-            rule.automerge === false,
-        'the CSS preprocessor automerge exception'
+    assert.equal(
+        rules.find((rule) => rule.matchPackageNames?.includes('postcss') && rule.automerge === false),
+        undefined,
+        'CSS preprocessor updates must not be excluded from automerge'
     );
     const tryGhostExceptionRule = findRule(
         rules,
@@ -123,7 +117,6 @@ function assertQuietPolicy(shallowConfig, fullConfig) {
             rule.automerge === false,
         'the TryGhost major-update automerge exception'
     );
-    assert.ok(rules.indexOf(broadAutomergeRule) < rules.indexOf(cssExceptionRule));
     assert.ok(rules.indexOf(broadAutomergeRule) < rules.indexOf(tryGhostExceptionRule));
     findRule(
         rules,
@@ -228,12 +221,12 @@ function assertConfigSpecificPolicy(shallowEvent, fullConfig) {
     assertQuietPolicy(shallowConfig, fullConfig);
 
     const expectedRuleCounts = new Map([
-        ['.github/renovate.json5', 9],
-        ['default.json', 9],
-        ['quiet.json5', 9],
-        ['renovate-config.json', 9],
-        ['safe.json', 10],
-        ['theme.json5', 11]
+        ['.github/renovate.json5', 8],
+        ['default.json', 8],
+        ['quiet.json5', 8],
+        ['renovate-config.json', 8],
+        ['safe.json', 9],
+        ['theme.json5', 10]
     ]);
     assert.equal(shallowConfig.packageRules.length, expectedRuleCounts.get(configFile));
 

--- a/test/assert-preset.mjs
+++ b/test/assert-preset.mjs
@@ -105,11 +105,6 @@ function assertQuietPolicy(shallowConfig, fullConfig) {
         'action',
         'uses-with'
     ]);
-    assert.equal(
-        rules.find((rule) => rule.matchPackageNames?.includes('postcss') && rule.automerge === false),
-        undefined,
-        'CSS preprocessor updates must not be excluded from automerge'
-    );
     const tryGhostExceptionRule = findRule(
         rules,
         (rule) => rule.matchPackageNames?.includes('gscan') &&


### PR DESCRIPTION
## Summary

Removes the `Do not automerge CSS preprocessors` rule from `quiet.json5` so PostCSS/Sass/Less/Stylus/Stylelint/Tailwind/etc. follow the same automerge policy as every other dependency. The `Group CSS preprocessors` grouping rule is unchanged.

## Why

The exclusion existed on the theory that style toolchain updates could cause visual regressions. Minor/patch bumps to these packages don't do that in practice, and the rule was causing PRs to back up on every consumer repo. Majors remain subject to each repo's existing major-update policy (dashboard approval in Ghost). Repos that want manual review for these can add a local override.

## Affected consumers

Every repo extending `github>tryghost/renovate-config` (default/quiet/theme). Open Renovate PRs for these packages will become automergeable on the next run.

## Verification

`npx --yes --package=renovate@43.262.2 --call './test/run.sh'` — passes; harness rule counts decremented.