### PR TITLE
Changed rebaseWhen from conflicted to auto

### DIFF
--- a/quiet.json5
+++ b/quiet.json5
@@ -28,12 +28,12 @@
     // Don't have separate PRs for minor and patch updates
     "separateMinorPatch": false,
     // https://docs.renovatebot.com/configuration-options/#rebasewhen
-    // Rebase only when a branch actually conflicts. "automerging" resolves to
-    // "never" for any PR a package rule excludes from automerge, so those PRs
-    // went stale; "behind-base-branch" force-pushes and re-runs CI on every
-    // base commit for no gain when branch protection doesn't require branches
-    // to be up to date.
-    "rebaseWhen": "conflicted",
+    // "auto" resolves per branch: automerge PRs, and every PR on repos whose
+    // branch protection requires up-to-date branches, rebase whenever behind;
+    // everything else rebases only on conflict. "automerging" resolved to
+    // "never" for non-automerge PRs (they went stale); "conflicted" stalls
+    // automerge on repos that require up-to-date branches.
+    "rebaseWhen": "auto",
     // Run `yarn-deduplicate --strategy highest` after yarn.lock updates
     "postUpdateOptions": [
         "yarnDedupeHighest"

--- a/test/assert-preset.mjs
+++ b/test/assert-preset.mjs
@@ -82,7 +82,7 @@ function isBroadAutomergeRule(rule) {
 function assertQuietPolicy(shallowConfig, fullConfig) {
     assert.equal(shallowConfig.separateMultipleMajor, false);
     assert.equal(shallowConfig.separateMinorPatch, false);
-    assert.equal(shallowConfig.rebaseWhen, 'conflicted');
+    assert.equal(shallowConfig.rebaseWhen, 'auto');
     assert.deepEqual(shallowConfig.postUpdateOptions, ['yarnDedupeHighest']);
     assert.equal(shallowConfig.lockFileMaintenance.automerge, true);
 


### PR DESCRIPTION
## Summary

Follow-up to #30. Changes `rebaseWhen` in `quiet.json5` from `conflicted` to `auto`.

## Why

`conflicted` does not rebase a green-but-behind branch. On repos whose ruleset has `strict_required_status_checks_policy: true` (require branches to be up to date before merging) the platform then refuses the merge, so automerge stalls until something conflicts. Most consumer repos are strict: Casper, Themes, framework, gscan, migrate, Actions, express-hbs, Zapier, algolia.

`auto` resolves per branch (see Renovate's `determineRebaseWhenValue`):
- automerge PRs → `behind-base-branch` (same as the old `automerging` behaviour)
- any PR on a repo that requires up-to-date branches → `behind-base-branch`
- everything else → `conflicted` (the improvement #30 was after — non-automerge PRs no longer resolve to `never`)

Ghost keeps its local `conflicted` override; its ruleset is non-strict so it doesn't hit this.

## Verification

`npx --yes --package=renovate@43.262.2 --call './test/run.sh'` passes.